### PR TITLE
conditionally fall back to using tag, title

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func getConfigAuditReportFindings(body []byte) ([]types.AwsSecurityFinding, erro
 		// Truncate description if too long
 		description := check.Description
 		if len(description) > 1024 {
-			description = description[:1024] + "..."
+			description = description[:1021] + "..."
 		}
 
 		findings = append(findings, types.AwsSecurityFinding{
@@ -292,7 +292,7 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 		}
 		// Truncate description if too long
 		if len(description) > 1024 {
-			description = description[:1024] + "..."
+			description = description[:1021] + "..."
 		}
 
 		findings = append(findings, types.AwsSecurityFinding{

--- a/main.go
+++ b/main.go
@@ -266,13 +266,13 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 	Registry := vulnerabilityReport.Report.Registry.Server
 	Repository := vulnerabilityReport.Report.Artifact.Repository
 	Digest := vulnerabilityReport.Report.Artifact.Digest
+	FullImageName := fmt.Sprintf("%s/%s@%s", Registry, Repository, Digest)
 	Tag := vulnerabilityReport.Report.Artifact.Tag
 	// use tag if digest is empty
 	if Digest == "" {
-		Digest = Tag
+		FullImageName = fmt.Sprintf("%s/%s:%s", Registry, Repository, Tag)
 	}
 
-	FullImageName := fmt.Sprintf("%s/%s@%s", Registry, Repository, Digest)
 	ImageName := fmt.Sprintf("%s/%s", Registry, Repository)
 
 	// Prepare findings for AWS Security Hub BatchImportFindings API

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ This application processes vulnerability reports from Trivy, a vulnerability sca
 - **AWS Account**: This application uses AWS Security Hub to store and manage security findings, so you must have an active AWS account and the necessary permissions.
 - **Trivy**: You must set up Trivy to scan container images and send reports to the webhook endpoint.
 - **Go**: The application is written in Go, so you'll need Go installed to build and run it.
+- **Security Hub Integration**: You must accept findings from `Aqua Security: Aqua Security` in AWS Security Hub. This allows the application to import findings into Security Hub.
   
 ## Setup and Installation
 


### PR DESCRIPTION
This PR makes a few small changes:

- The `digest` in `VulnerabilityReport` is not available, but the `tag` is, fall back to using `tag` if digest is not available
- By default `description` is not enabled for `VulnerabilityReport`, to improve UX default to using the `title`, otherwise security hub marks the import as invalid since `description` is a required field.
- increase the length of `description` to 1024 max as defined by [AwsSecurityFinding](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/securityhub@v1.54.3/types#AwsSecurityFinding) 
- update docs to reflect enabling security hub integration - related to https://github.com/csepulveda/trivy-webhook-aws-security-hub/issues/6