### PR TITLE
feat: add option to include AWS account IDs in finding IDs to ensure uniqueness across accounts

### DIFF
--- a/charts/trivy-webhook-aws-security-hub/readme.md
+++ b/charts/trivy-webhook-aws-security-hub/readme.md
@@ -62,7 +62,7 @@ All configuration is done via `values.yaml` or `--set` in the Helm CLI.
 | `config.CONFIG_AUDIT_ENABLE`              | Enable Config Audit report processing                                         | `"false"`       |
 | `config.CLUSTER_COMPLIANCE_ENABLE`        | Enable Cluster Compliance report processing                                   | `"false"`       |
 | `config.VULNERABILITY_ENABLE`             | Enable Vulnerability report processing                                        | `"true"`        |
-| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Include AWS Account ID in the finding ID to ensure uniqueness across accounts | `"true"`        |
+| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Include AWS Account ID in the finding ID to ensure uniqueness across accounts | `"false"`        |
 > These environment variables control what types of Trivy reports are processed and sent to AWS Security Hub.
 
 ---

--- a/charts/trivy-webhook-aws-security-hub/readme.md
+++ b/charts/trivy-webhook-aws-security-hub/readme.md
@@ -55,14 +55,14 @@ All configuration is done via `values.yaml` or `--set` in the Helm CLI.
 
 ### App Configuration (`config` block)
 
-| Name                                | Description                                        | Default          |
-|-------------------------------------|--------------------------------------------------|------------------|
-| `config.AWS_REGION`                  | AWS region for Security Hub                      | `eu-central-1`   |
-| `config.INFRA_ASSESSMENT_ENABLE`     | Enable Infra Assessment report processing        | `"false"`         |
-| `config.CONFIG_AUDIT_ENABLE`         | Enable Config Audit report processing            | `"false"`         |
-| `config.CLUSTER_COMPLIANCE_ENABLE`  | Enable Cluster Compliance report processing     | `"false"`         |
-| `config.VULNERABILITY_ENABLE`        | Enable Vulnerability report processing           | `"true"`         |
-
+| Name                                      | Description                                                                   | Default         |
+|-------------------------------------------|-------------------------------------------------------------------------------|-----------------|
+| `config.AWS_REGION`                       | AWS region for Security Hub                                                   | `eu-central-1`  |
+| `config.INFRA_ASSESSMENT_ENABLE`          | Enable Infra Assessment report processing                                     | `"false"`       |
+| `config.CONFIG_AUDIT_ENABLE`              | Enable Config Audit report processing                                         | `"false"`       |
+| `config.CLUSTER_COMPLIANCE_ENABLE`        | Enable Cluster Compliance report processing                                   | `"false"`       |
+| `config.VULNERABILITY_ENABLE`             | Enable Vulnerability report processing                                        | `"true"`        |
+| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Include AWS Account ID in the finding ID to ensure uniqueness across accounts | `"true"`        |
 > These environment variables control what types of Trivy reports are processed and sent to AWS Security Hub.
 
 ---

--- a/charts/trivy-webhook-aws-security-hub/templates/deployment.yaml
+++ b/charts/trivy-webhook-aws-security-hub/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
               value: {{ .Values.config.CLUSTER_COMPLIANCE_ENABLE | quote }}
             - name: VULNERABILITY_ENABLE
               value: {{ .Values.config.VULNERABILITY_ENABLE | quote }}
+            - name: INCLUDE_ACCOUNT_ID_IN_FINDING_ID
+              value: {{ .Values.config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID | quote }}
             {{ if .Values.extraenvs }}
               {{- toYaml .Values.extraenvs | nindent 12 }}
             {{- end }}

--- a/charts/trivy-webhook-aws-security-hub/values.yaml
+++ b/charts/trivy-webhook-aws-security-hub/values.yaml
@@ -33,12 +33,14 @@ fullnameOverride: ""
 ## @description config.CONFIG_AUDIT_ENABLE: Enable configuration audit.
 ## @description config.CLUSTER_COMPLIANCE_ENABLE: Enable cluster compliance.
 ## @description config.VULNERABILITY_ENABLE: Enable vulnerability assessment.
+## @description config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID: Include AWS Account ID in finding ID.
 config:
   AWS_REGION: eu-central-1
   INFRA_ASSESSMENT_ENABLE: false
   CONFIG_AUDIT_ENABLE: false
   CLUSTER_COMPLIANCE_ENABLE: false
   VULNERABILITY_ENABLE: true
+  INCLUDE_ACCOUNT_ID_IN_FINDING_ID: false
 
 ## @param extraenvs [array] Extra environment variables to set for the trivy-webhook container.
 ## @description Extra environment variables to set for the trivy-webhook container.

--- a/main.go
+++ b/main.go
@@ -27,18 +27,20 @@ type webhook struct {
 
 // Config holds feature flags
 type Config struct {
-	InfraAssessmentEnable   bool
-	ConfigAuditEnable       bool
-	ClusterComplianceEnable bool
-	VulnerabilityEnable     bool
+	InfraAssessmentEnable       bool
+	ConfigAuditEnable           bool
+	ClusterComplianceEnable     bool
+	VulnerabilityEnable         bool
+	IncludeAccountIDInFindingID bool
 }
 
 func LoadConfig() Config {
 	return Config{
-		InfraAssessmentEnable:   tools.ParseEnvBool("INFRA_ASSESSMENT_ENABLE", true),
-		ConfigAuditEnable:       tools.ParseEnvBool("CONFIG_AUDIT_ENABLE", true),
-		ClusterComplianceEnable: tools.ParseEnvBool("CLUSTER_COMPLIANCE_ENABLE", true),
-		VulnerabilityEnable:     tools.ParseEnvBool("VULNERABILITY_ENABLE", true),
+		InfraAssessmentEnable:       tools.ParseEnvBool("INFRA_ASSESSMENT_ENABLE", true),
+		ConfigAuditEnable:           tools.ParseEnvBool("CONFIG_AUDIT_ENABLE", true),
+		ClusterComplianceEnable:     tools.ParseEnvBool("CLUSTER_COMPLIANCE_ENABLE", true),
+		VulnerabilityEnable:         tools.ParseEnvBool("VULNERABILITY_ENABLE", true),
+		IncludeAccountIDInFindingID: tools.ParseEnvBool("INCLUDE_ACCOUNT_ID_IN_FINDING_ID", false),
 	}
 }
 
@@ -78,7 +80,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 		switch report.Kind {
 		case "ConfigAuditReport":
 			if cfg.ConfigAuditEnable {
-				findings, err = getConfigAuditReportFindings(body)
+				findings, err = getConfigAuditReportFindings(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -87,7 +89,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 			}
 		case "InfraAssessmentReport":
 			if cfg.InfraAssessmentEnable {
-				findings, err = getInfraAssessmentReport(body)
+				findings, err = getInfraAssessmentReport(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -96,7 +98,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 			}
 		case "ClusterComplianceReport":
 			if cfg.ClusterComplianceEnable {
-				findings, err = getClusterComplianceReport(body)
+				findings, err = getClusterComplianceReport(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -105,7 +107,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 			}
 		case "VulnerabilityReport":
 			if cfg.VulnerabilityEnable {
-				findings, err = getVulnerabilityReportFindings(body)
+				findings, err = getVulnerabilityReportFindings(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -136,7 +138,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 	}
 }
 
-func getConfigAuditReportFindings(body []byte) ([]types.AwsSecurityFinding, error) {
+func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	configAuditReport := &v1alpha1.ConfigAuditReport{}
 
 	// Decode JSON
@@ -181,9 +183,15 @@ func getConfigAuditReportFindings(body []byte) ([]types.AwsSecurityFinding, erro
 			description = description[:1021] + "..."
 		}
 
+		findingID := fmt.Sprintf("%s-%s", check.ID, Name)
+		// Optionally include AWS Account ID in the finding ID to ensure uniqueness across accounts
+		if appCfg.IncludeAccountIDInFindingID {
+			findingID = fmt.Sprintf("%s-%s-%s", AWSAccountID, check.ID, Name)
+		}
+
 		findings = append(findings, types.AwsSecurityFinding{
 			SchemaVersion: aws.String("2018-10-08"),
-			Id:            aws.String(fmt.Sprintf("%s-%s", check.ID, Name)),
+			Id:            aws.String(findingID),
 			ProductArn:    aws.String(ProductArn),
 			GeneratorId:   aws.String(fmt.Sprintf("Trivy/%s", check.ID)),
 			AwsAccountId:  aws.String(AWSAccountID),
@@ -219,7 +227,7 @@ func getConfigAuditReportFindings(body []byte) ([]types.AwsSecurityFinding, erro
 	return findings, nil
 }
 
-func getInfraAssessmentReport(body []byte) ([]types.AwsSecurityFinding, error) {
+func getInfraAssessmentReport(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	infraAssessmentReport := &v1alpha1.InfraAssessmentReport{}
 
 	// Decode JSON
@@ -243,7 +251,7 @@ func getInfraAssessmentReport(body []byte) ([]types.AwsSecurityFinding, error) {
 	return findings, nil
 }
 
-func getClusterComplianceReport(body []byte) ([]types.AwsSecurityFinding, error) {
+func getClusterComplianceReport(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	clusterComplianceReport := &v1alpha1.ClusterComplianceReport{}
 
 	// Decode JSON
@@ -267,7 +275,7 @@ func getClusterComplianceReport(body []byte) ([]types.AwsSecurityFinding, error)
 	return findings, nil
 }
 
-func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, error) {
+func getVulnerabilityReportFindings(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	vulnerabilityReport := &v1alpha1.VulnerabilityReport{}
 
 	// Decode JSON
@@ -327,9 +335,15 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 			description = description[:1021] + "..."
 		}
 
+		findingID := fmt.Sprintf("%s-%s", FullImageName, vulnerabilities.VulnerabilityID)
+		// Optionally include AWS Account ID in the finding ID to ensure uniqueness across accounts
+		if appCfg.IncludeAccountIDInFindingID {
+			findingID = fmt.Sprintf("%s-%s-%s", AWSAccountID, FullImageName, vulnerabilities.VulnerabilityID)
+		}
+
 		findings = append(findings, types.AwsSecurityFinding{
 			SchemaVersion: aws.String("2018-10-08"),
-			Id:            aws.String(fmt.Sprintf("%s-%s", FullImageName, vulnerabilities.VulnerabilityID)),
+			Id:            aws.String(findingID),
 			ProductArn:    aws.String(ProductArn),
 			GeneratorId:   aws.String(fmt.Sprintf("Trivy/%s", vulnerabilities.VulnerabilityID)),
 			AwsAccountId:  aws.String(AWSAccountID),

--- a/readme.md
+++ b/readme.md
@@ -66,15 +66,16 @@ curl -X POST -H "Content-Type: application/json" --data @result.json http://loca
 
 ## ⚙️ Environment Variables
 
-| Variable Name               | Description                                              | Default  |
-|----------------------------|----------------------------------------------------------|----------|
-| `INFRA_ASSESSMENT_ENABLE`   | Enable processing of InfraAssessmentReport              | `false`  |
-| `CONFIG_AUDIT_ENABLE`       | Enable processing of ConfigAuditReport                  | `false`  |
-| `CLUSTER_COMPLIANCE_ENABLE` | Enable processing of ClusterComplianceReport            | `false`  |
-| `VULNERABILITY_ENABLE`      | Enable processing of VulnerabilityReport                | `true`   |
-| `AWS_ACCESS_KEY_ID`         | AWS Access Key (standard AWS SDK var)                   | *N/A*    |
-| `AWS_SECRET_ACCESS_KEY`     | AWS Secret Key (standard AWS SDK var)                   | *N/A*    |
-| `AWS_REGION`                | AWS Region where Security Hub is enabled                | *N/A*    |
+| Variable Name                          | Description                                                                   | Default |
+| -------------------------------------- | ----------------------------------------------------------------------------- | ------- |
+| `INFRA_ASSESSMENT_ENABLE`              | Enable processing of InfraAssessmentReport                                    | `false` |
+| `CONFIG_AUDIT_ENABLE`                  | Enable processing of ConfigAuditReport                                        | `false` |
+| `CLUSTER_COMPLIANCE_ENABLE`            | Enable processing of ClusterComplianceReport                                  | `false` |
+| `VULNERABILITY_ENABLE`                 | Enable processing of VulnerabilityReport                                      | `true`  |
+| `INCLUDE_ACCOUNT_ID_IN_FINDING_ID`     | Include AWS Account ID in the finding ID to ensure uniqueness across accounts | `false` |
+| `AWS_ACCESS_KEY_ID`                    | AWS Access Key (standard AWS SDK var)                                         | *N/A*   |
+| `AWS_SECRET_ACCESS_KEY`                | AWS Secret Key (standard AWS SDK var)                                         | *N/A*   |
+| `AWS_REGION`                           | AWS Region where Security Hub is enabled                                      | *N/A*   |
 
 Example configuration:
 


### PR DESCRIPTION
Hi @csepulveda ,

thank you for creating this integration. We tested it within our team and like it a lot so far, but we ran into one issue.

Our Security Hub CSPM is centrally managed for all member accounts in our AWS Organization. These accounts host different environments of the same systems, such as development, staging, and production. As a result, Trivy often detects the same vulnerabilities across multiple accounts as they may run the same containers from the same registry.

It appears that when findings are imported into Security Hub with the same finding ID and product ID, they are shown only once in the dashboard of a single member account. This creates the misleading impression that a given finding exists in only one account, even though it may actually be present in several.

To address this, I added an option to generate account-specific finding IDs. This ensures that equivalent findings are displayed in each affected member account dashboard.

Please let me know what you think of this PR and if it needs any adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New option to include the AWS Account ID as a prefix in finding IDs for uniqueness across accounts (off by default).

* **Documentation**
  * Updated docs and chart values with the new option, reflowed environment variables table, and added an example YAML showing how to enable it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->