### PR TITLE
Include Kubernetes namespace in Security Hub findings

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,6 +34,7 @@ type Config struct {
 	VulnerabilityEnable     bool
 }
 
+// LoadConfig reads feature flags from environment variables.
 func LoadConfig() Config {
 	return Config{
 		InfraAssessmentEnable:   tools.ParseEnvBool("INFRA_ASSESSMENT_ENABLE", true),
@@ -42,6 +44,7 @@ func LoadConfig() Config {
 	}
 }
 
+// PrintConfig logs the active feature flag configuration.
 func PrintConfig(cfg Config) {
 	log.Printf("Loaded Configuration: %+v", cfg)
 }
@@ -334,9 +337,13 @@ func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.Vulnerabilit
 			description = description[:1021] + "..."
 		}
 
+		findingID := truncateWithHash(fmt.Sprintf("%s-%s-%s", Namespace, FullImageName, vulnerabilities.VulnerabilityID), 512)
+		title := truncateWithHash(fmt.Sprintf("%s/%s/%s:%s %s", Namespace, ImageName, Container, Tag, vulnerabilities.VulnerabilityID), 256)
+		resourceID := truncateWithHash(fmt.Sprintf("%s/%s", Namespace, ImageName), 512)
+
 		findings = append(findings, types.AwsSecurityFinding{
 			SchemaVersion: aws.String("2018-10-08"),
-			Id:            aws.String(fmt.Sprintf("%s-%s-%s", Namespace, FullImageName, vulnerabilities.VulnerabilityID)),
+			Id:            aws.String(findingID),
 			ProductArn:    aws.String(ProductArn),
 			GeneratorId:   aws.String(fmt.Sprintf("Trivy/%s", vulnerabilities.VulnerabilityID)),
 			AwsAccountId:  aws.String(AWSAccountID),
@@ -344,7 +351,7 @@ func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.Vulnerabilit
 			CreatedAt:     aws.String(time.Now().Format(time.RFC3339)),
 			UpdatedAt:     aws.String(time.Now().Format(time.RFC3339)),
 			Severity:      &types.Severity{Label: types.SeverityLabel(severity)},
-			Title:         aws.String(fmt.Sprintf("%s/%s:%s %s", ImageName, Container, Tag, vulnerabilities.VulnerabilityID)),
+			Title:         aws.String(title),
 			Description:   aws.String(description),
 			Remediation: &types.Remediation{
 				Recommendation: &types.Recommendation{
@@ -352,11 +359,14 @@ func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.Vulnerabilit
 					Url:  aws.String(vulnerabilities.PrimaryLink),
 				},
 			},
-			ProductFields: map[string]string{"Product Name": "Trivy"},
+			ProductFields: map[string]string{
+				"Product Name": "Trivy",
+				"Namespace":    Namespace,
+			},
 			Resources: []types.Resource{
 				{
 					Type:      aws.String("Container"),
-					Id:        aws.String(ImageName),
+					Id:        aws.String(resourceID),
 					Partition: types.PartitionAws,
 					Region:    aws.String(AWSRegion),
 					Details: &types.ResourceDetails{
@@ -380,6 +390,24 @@ func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.Vulnerabilit
 	}
 
 	return findings
+}
+
+func truncateWithHash(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	if maxLen <= 0 {
+		return ""
+	}
+
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(s)))
+	suffix := "-" + hash[:12]
+	if maxLen <= len(suffix) {
+		return hash[:maxLen]
+	}
+
+	return string(runes[:maxLen-len(suffix)]) + suffix
 }
 
 // Import findings to AWS Security Hub in batches of 100

--- a/main.go
+++ b/main.go
@@ -293,7 +293,14 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 	// Prepare variables
 	AWSAccountID := aws.ToString(callerIdentity.Account)
 	AWSRegion := cfg.Region
+
+	return buildVulnerabilityReportFindings(vulnerabilityReport, AWSAccountID, AWSRegion), nil
+}
+
+func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.VulnerabilityReport, AWSAccountID string, AWSRegion string) []types.AwsSecurityFinding {
 	ProductArn := fmt.Sprintf("arn:aws:securityhub:%s::product/aquasecurity/aquasecurity", AWSRegion)
+	Namespace := vulnerabilityReport.Namespace
+	ReportName := vulnerabilityReport.Name
 	Container := vulnerabilityReport.Labels["trivy-operator.container.name"]
 	Registry := vulnerabilityReport.Report.Registry.Server
 	Repository := vulnerabilityReport.Report.Artifact.Repository
@@ -329,7 +336,7 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 
 		findings = append(findings, types.AwsSecurityFinding{
 			SchemaVersion: aws.String("2018-10-08"),
-			Id:            aws.String(fmt.Sprintf("%s-%s", FullImageName, vulnerabilities.VulnerabilityID)),
+			Id:            aws.String(fmt.Sprintf("%s-%s-%s", Namespace, FullImageName, vulnerabilities.VulnerabilityID)),
 			ProductArn:    aws.String(ProductArn),
 			GeneratorId:   aws.String(fmt.Sprintf("Trivy/%s", vulnerabilities.VulnerabilityID)),
 			AwsAccountId:  aws.String(AWSAccountID),
@@ -354,14 +361,16 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 					Region:    aws.String(AWSRegion),
 					Details: &types.ResourceDetails{
 						Other: map[string]string{
-							"Container Image":   ImageName,
-							"CVE ID":            vulnerabilities.VulnerabilityID,
-							"CVE Title":         vulnerabilities.Title,
-							"PkgName":           vulnerabilities.Resource,
-							"Installed Package": vulnerabilities.InstalledVersion,
-							"Patched Package":   vulnerabilities.FixedVersion,
-							"NvdCvssScoreV3":    fmt.Sprintf("%f", tools.GetVulnScore(vulnerabilities)),
-							"NvdCvssVectorV3":   "",
+							"Kubernetes Namespace": Namespace,
+							"Kubernetes Report":    ReportName,
+							"Container Image":      ImageName,
+							"CVE ID":               vulnerabilities.VulnerabilityID,
+							"CVE Title":            vulnerabilities.Title,
+							"PkgName":              vulnerabilities.Resource,
+							"Installed Package":    vulnerabilities.InstalledVersion,
+							"Patched Package":      vulnerabilities.FixedVersion,
+							"NvdCvssScoreV3":       fmt.Sprintf("%f", tools.GetVulnScore(vulnerabilities)),
+							"NvdCvssVectorV3":      "",
 						},
 					},
 				},
@@ -370,7 +379,7 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 		})
 	}
 
-	return findings, err
+	return findings
 }
 
 // Import findings to AWS Security Hub in batches of 100

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
@@ -48,12 +49,65 @@ func TestBuildVulnerabilityReportFindingsIncludesNamespace(t *testing.T) {
 
 	finding := findings[0]
 	assert.Contains(t, aws.ToString(finding.Id), "payments-")
-	assert.Contains(t, aws.ToString(finding.Title), "namespace payments")
-	assert.Equal(t, "payments", finding.ProductFields["Kubernetes Namespace"])
-	assert.Equal(t, "replicaset-nginx-7c9d", finding.ProductFields["Kubernetes Report"])
+	assert.Contains(t, aws.ToString(finding.Title), "payments/")
+	assert.Equal(t, "payments", finding.ProductFields["Namespace"])
 
 	require.Len(t, finding.Resources, 1)
 	assert.Equal(t, "payments/111122223333.dkr.ecr.eu-central-1.amazonaws.com/platform/nginx", aws.ToString(finding.Resources[0].Id))
 	assert.Equal(t, "payments", finding.Resources[0].Details.Other["Kubernetes Namespace"])
 	assert.Equal(t, "replicaset-nginx-7c9d", finding.Resources[0].Details.Other["Kubernetes Report"])
+}
+
+func TestBuildVulnerabilityReportFindingsTruncatesSecurityHubFields(t *testing.T) {
+	longNamespace := strings.Repeat("namespace-", 20)
+	longRegistry := strings.Repeat("registry", 25) + ".example.com"
+	longRepository := strings.Repeat("repository/", 40) + "image"
+	longContainer := strings.Repeat("container-", 20)
+	longTag := strings.Repeat("tag", 100)
+	longVulnerabilityID := "CVE-" + strings.Repeat("2026-", 100)
+
+	report := &v1alpha1.VulnerabilityReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "long-report",
+			Namespace: longNamespace,
+			Labels: map[string]string{
+				"trivy-operator.container.name": longContainer,
+			},
+		},
+		Report: v1alpha1.VulnerabilityReportData{
+			Registry: v1alpha1.Registry{Server: longRegistry},
+			Artifact: v1alpha1.Artifact{
+				Repository: longRepository,
+				Tag:        longTag,
+			},
+			Vulnerabilities: []v1alpha1.Vulnerability{
+				{
+					VulnerabilityID: longVulnerabilityID,
+					Severity:        v1alpha1.SeverityHigh,
+					Title:           "test vulnerability",
+				},
+			},
+		},
+	}
+
+	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1")
+
+	require.Len(t, findings, 1)
+	assert.LessOrEqual(t, len([]rune(aws.ToString(findings[0].Id))), 512)
+	assert.LessOrEqual(t, len([]rune(aws.ToString(findings[0].Title))), 256)
+	require.Len(t, findings[0].Resources, 1)
+	assert.LessOrEqual(t, len([]rune(aws.ToString(findings[0].Resources[0].Id))), 512)
+}
+
+func TestTruncateWithHash(t *testing.T) {
+	short := "short-value"
+	assert.Equal(t, short, truncateWithHash(short, 512))
+
+	long := strings.Repeat("a", 600)
+	truncated := truncateWithHash(long, 512)
+
+	assert.Len(t, []rune(truncated), 512)
+	assert.Equal(t, truncated, truncateWithHash(long, 512))
+	assert.NotEqual(t, truncated, truncateWithHash(long+"b", 512))
+	assert.Contains(t, truncated, "-")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildVulnerabilityReportFindingsIncludesNamespace(t *testing.T) {
+	report := &v1alpha1.VulnerabilityReport{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VulnerabilityReport",
+			APIVersion: "aquasecurity.github.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "replicaset-nginx-7c9d",
+			Namespace: "payments",
+			Labels: map[string]string{
+				"trivy-operator.container.name": "nginx",
+			},
+		},
+		Report: v1alpha1.VulnerabilityReportData{
+			Registry: v1alpha1.Registry{Server: "111122223333.dkr.ecr.eu-central-1.amazonaws.com"},
+			Artifact: v1alpha1.Artifact{
+				Repository: "platform/nginx",
+				Tag:        "1.25.0",
+			},
+			Vulnerabilities: []v1alpha1.Vulnerability{
+				{
+					VulnerabilityID:  "CVE-2026-0001",
+					Resource:         "openssl",
+					InstalledVersion: "1.0.0",
+					FixedVersion:     "1.0.1",
+					Severity:         v1alpha1.SeverityHigh,
+					Title:            "test vulnerability",
+				},
+			},
+		},
+	}
+
+	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1")
+
+	require.Len(t, findings, 1)
+
+	finding := findings[0]
+	assert.Contains(t, aws.ToString(finding.Id), "payments-")
+	assert.Contains(t, aws.ToString(finding.Title), "namespace payments")
+	assert.Equal(t, "payments", finding.ProductFields["Kubernetes Namespace"])
+	assert.Equal(t, "replicaset-nginx-7c9d", finding.ProductFields["Kubernetes Report"])
+
+	require.Len(t, finding.Resources, 1)
+	assert.Equal(t, "payments/111122223333.dkr.ecr.eu-central-1.amazonaws.com/platform/nginx", aws.ToString(finding.Resources[0].Id))
+	assert.Equal(t, "payments", finding.Resources[0].Details.Other["Kubernetes Namespace"])
+	assert.Equal(t, "replicaset-nginx-7c9d", finding.Resources[0].Details.Other["Kubernetes Report"])
+}


### PR DESCRIPTION
## Summary

Add Kubernetes namespace context to AWS Security Hub findings generated from Trivy `VulnerabilityReport` events.

Trivy Operator already includes the workload namespace in the incoming report metadata and labels, but the webhook did not forward that value into Security Hub. This change includes the namespace in the generated finding so findings can be filtered and identified by Kubernetes namespace in Security Hub.

## Changes

- Extract namespace from the decoded `VulnerabilityReport`
- Include namespace in:
  - Security Hub finding ID
  - finding title
  - `ProductFields`
  - resource ID
  - `Resources[].Details.Other`
- Add unit test coverage for namespace propagation in generated findings

## Validation

```bash
go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vulnerability findings now embed Kubernetes Namespace in IDs, titles, and product metadata for clearer context.
  * Resource details now surface Kubernetes-specific fields (Kubernetes Namespace and Kubernetes Report).
  * Long finding identifiers and titles are deterministically truncated with a stable suffix to meet length limits.

* **Tests**
  * Added tests validating namespace/report propagation and deterministic truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->