### PR TITLE
feat: add option to include AWS account ID in finding IDs

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,19 +28,21 @@ type webhook struct {
 
 // Config holds feature flags
 type Config struct {
-	InfraAssessmentEnable   bool
-	ConfigAuditEnable       bool
-	ClusterComplianceEnable bool
-	VulnerabilityEnable     bool
+	InfraAssessmentEnable       bool
+	ConfigAuditEnable           bool
+	ClusterComplianceEnable     bool
+	VulnerabilityEnable         bool
+	IncludeAccountIDInFindingID bool
 }
 
 // LoadConfig reads feature flags from environment variables.
 func LoadConfig() Config {
 	return Config{
-		InfraAssessmentEnable:   tools.ParseEnvBool("INFRA_ASSESSMENT_ENABLE", true),
-		ConfigAuditEnable:       tools.ParseEnvBool("CONFIG_AUDIT_ENABLE", true),
-		ClusterComplianceEnable: tools.ParseEnvBool("CLUSTER_COMPLIANCE_ENABLE", true),
-		VulnerabilityEnable:     tools.ParseEnvBool("VULNERABILITY_ENABLE", true),
+		InfraAssessmentEnable:       tools.ParseEnvBool("INFRA_ASSESSMENT_ENABLE", true),
+		ConfigAuditEnable:           tools.ParseEnvBool("CONFIG_AUDIT_ENABLE", true),
+		ClusterComplianceEnable:     tools.ParseEnvBool("CLUSTER_COMPLIANCE_ENABLE", true),
+		VulnerabilityEnable:         tools.ParseEnvBool("VULNERABILITY_ENABLE", true),
+		IncludeAccountIDInFindingID: tools.ParseEnvBool("INCLUDE_ACCOUNT_ID_IN_FINDING_ID", false),
 	}
 }
 
@@ -81,7 +83,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 		switch report.Kind {
 		case "ConfigAuditReport":
 			if cfg.ConfigAuditEnable {
-				findings, err = getConfigAuditReportFindings(body)
+				findings, err = getConfigAuditReportFindings(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -90,7 +92,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 			}
 		case "InfraAssessmentReport":
 			if cfg.InfraAssessmentEnable {
-				findings, err = getInfraAssessmentReport(body)
+				findings, err = getInfraAssessmentReport(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -99,7 +101,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 			}
 		case "ClusterComplianceReport":
 			if cfg.ClusterComplianceEnable {
-				findings, err = getClusterComplianceReport(body)
+				findings, err = getClusterComplianceReport(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -108,7 +110,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 			}
 		case "VulnerabilityReport":
 			if cfg.VulnerabilityEnable {
-				findings, err = getVulnerabilityReportFindings(body)
+				findings, err = getVulnerabilityReportFindings(body, cfg)
 				if err != nil {
 					http.Error(w, "Error processing report", http.StatusInternalServerError)
 					log.Printf("Error processing report: %v", err)
@@ -139,7 +141,7 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 	}
 }
 
-func getConfigAuditReportFindings(body []byte) ([]types.AwsSecurityFinding, error) {
+func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	configAuditReport := &v1alpha1.ConfigAuditReport{}
 
 	// Decode JSON
@@ -184,9 +186,14 @@ func getConfigAuditReportFindings(body []byte) ([]types.AwsSecurityFinding, erro
 			description = description[:1021] + "..."
 		}
 
+		findingID := fmt.Sprintf("%s-%s", check.ID, Name)
+		if appCfg.IncludeAccountIDInFindingID {
+			findingID = fmt.Sprintf("%s-%s-%s", AWSAccountID, check.ID, Name)
+		}
+
 		findings = append(findings, types.AwsSecurityFinding{
 			SchemaVersion: aws.String("2018-10-08"),
-			Id:            aws.String(fmt.Sprintf("%s-%s", check.ID, Name)),
+			Id:            aws.String(findingID),
 			ProductArn:    aws.String(ProductArn),
 			GeneratorId:   aws.String(fmt.Sprintf("Trivy/%s", check.ID)),
 			AwsAccountId:  aws.String(AWSAccountID),
@@ -222,7 +229,7 @@ func getConfigAuditReportFindings(body []byte) ([]types.AwsSecurityFinding, erro
 	return findings, nil
 }
 
-func getInfraAssessmentReport(body []byte) ([]types.AwsSecurityFinding, error) {
+func getInfraAssessmentReport(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	infraAssessmentReport := &v1alpha1.InfraAssessmentReport{}
 
 	// Decode JSON
@@ -246,7 +253,7 @@ func getInfraAssessmentReport(body []byte) ([]types.AwsSecurityFinding, error) {
 	return findings, nil
 }
 
-func getClusterComplianceReport(body []byte) ([]types.AwsSecurityFinding, error) {
+func getClusterComplianceReport(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	clusterComplianceReport := &v1alpha1.ClusterComplianceReport{}
 
 	// Decode JSON
@@ -270,7 +277,7 @@ func getClusterComplianceReport(body []byte) ([]types.AwsSecurityFinding, error)
 	return findings, nil
 }
 
-func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, error) {
+func getVulnerabilityReportFindings(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	vulnerabilityReport := &v1alpha1.VulnerabilityReport{}
 
 	// Decode JSON
@@ -297,10 +304,10 @@ func getVulnerabilityReportFindings(body []byte) ([]types.AwsSecurityFinding, er
 	AWSAccountID := aws.ToString(callerIdentity.Account)
 	AWSRegion := cfg.Region
 
-	return buildVulnerabilityReportFindings(vulnerabilityReport, AWSAccountID, AWSRegion), nil
+	return buildVulnerabilityReportFindings(vulnerabilityReport, AWSAccountID, AWSRegion, appCfg.IncludeAccountIDInFindingID), nil
 }
 
-func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.VulnerabilityReport, AWSAccountID string, AWSRegion string) []types.AwsSecurityFinding {
+func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.VulnerabilityReport, AWSAccountID string, AWSRegion string, includeAccountID bool) []types.AwsSecurityFinding {
 	ProductArn := fmt.Sprintf("arn:aws:securityhub:%s::product/aquasecurity/aquasecurity", AWSRegion)
 	Namespace := vulnerabilityReport.Namespace
 	ReportName := vulnerabilityReport.Name
@@ -337,7 +344,11 @@ func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.Vulnerabilit
 			description = description[:1021] + "..."
 		}
 
-		findingID := truncateWithHash(fmt.Sprintf("%s-%s-%s", Namespace, FullImageName, vulnerabilities.VulnerabilityID), 512)
+		rawFindingID := fmt.Sprintf("%s-%s-%s", Namespace, FullImageName, vulnerabilities.VulnerabilityID)
+		if includeAccountID {
+			rawFindingID = fmt.Sprintf("%s-%s-%s-%s", AWSAccountID, Namespace, FullImageName, vulnerabilities.VulnerabilityID)
+		}
+		findingID := truncateWithHash(rawFindingID, 512)
 		title := truncateWithHash(fmt.Sprintf("%s/%s/%s:%s %s", Namespace, ImageName, Container, Tag, vulnerabilities.VulnerabilityID), 256)
 		resourceID := truncateWithHash(fmt.Sprintf("%s/%s", Namespace, ImageName), 512)
 

--- a/main_test.go
+++ b/main_test.go
@@ -43,7 +43,7 @@ func TestBuildVulnerabilityReportFindingsIncludesNamespace(t *testing.T) {
 		},
 	}
 
-	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1")
+	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false)
 
 	require.Len(t, findings, 1)
 
@@ -90,13 +90,37 @@ func TestBuildVulnerabilityReportFindingsTruncatesSecurityHubFields(t *testing.T
 		},
 	}
 
-	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1")
+	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false)
 
 	require.Len(t, findings, 1)
 	assert.LessOrEqual(t, len([]rune(aws.ToString(findings[0].Id))), 512)
 	assert.LessOrEqual(t, len([]rune(aws.ToString(findings[0].Title))), 256)
 	require.Len(t, findings[0].Resources, 1)
 	assert.LessOrEqual(t, len([]rune(aws.ToString(findings[0].Resources[0].Id))), 512)
+}
+
+func TestBuildVulnerabilityReportFindingsIncludesAccountID(t *testing.T) {
+	report := &v1alpha1.VulnerabilityReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "replicaset-nginx-7c9d",
+			Namespace: "payments",
+			Labels:    map[string]string{"trivy-operator.container.name": "nginx"},
+		},
+		Report: v1alpha1.VulnerabilityReportData{
+			Registry: v1alpha1.Registry{Server: "docker.io"},
+			Artifact: v1alpha1.Artifact{Repository: "library/nginx", Tag: "1.25.0"},
+			Vulnerabilities: []v1alpha1.Vulnerability{
+				{VulnerabilityID: "CVE-2026-0001", Severity: v1alpha1.SeverityHigh, Title: "test"},
+			},
+		},
+	}
+
+	withoutAccount := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false)
+	withAccount := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", true)
+
+	require.Len(t, withAccount, 1)
+	assert.Contains(t, aws.ToString(withAccount[0].Id), "123456789012-")
+	assert.NotContains(t, aws.ToString(withoutAccount[0].Id), "123456789012-")
 }
 
 func TestTruncateWithHash(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` env var (default: `false`, backward compatible) to prefix finding IDs with the AWS Account ID
- Resolves conflicts from #14 (original PR by @LOHS020) with the refactored `buildVulnerabilityReportFindings` introduced in #16
- Adds `includeAccountID bool` parameter to `buildVulnerabilityReportFindings` to keep the function pure and testable
- Adds test `TestBuildVulnerabilityReportFindingsIncludesAccountID` covering the new flag

Closes #14

## Why

In AWS Organizations with centralized Security Hub, the same CVE on the same image generates the same finding ID across member accounts. Security Hub deduplicates by ID, so the finding appears only once even if it exists in dev, staging, and prod. This option disambiguates findings per account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional feature to include AWS Account ID in Security Hub finding IDs for audit and vulnerability findings. Can be enabled via environment configuration and is disabled by default for backward compatibility.

* **Tests**
  * Updated existing tests and added new tests to validate the new feature and its impact on finding ID generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->