### PR TITLE
add CONTRIBUTING.md and update chart docs for v0.1.18 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,8 @@ Releases are fully automated by GitHub Actions. To cut a release:
 1. Ensure all changes are merged to `main` and CI is green.
 2. Create and push a semver tag:
    ```bash
-   git tag v0.1.18
-   git push origin v0.1.18
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
    ```
 3. The `release.yml` workflow triggers automatically and:
    - Builds and pushes the Docker image to `ghcr.io/csepulveda/trivy-webhook-aws-security-hub:<tag>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing
+
+Thank you for your interest in contributing to `trivy-webhook-aws-security-hub`.
+
+## Development setup
+
+| Tool     | Version  | Purpose                        |
+|----------|----------|--------------------------------|
+| Go       | ≥ 1.26   | Build and unit tests           |
+| Docker   | any      | Image build, integration tests |
+| Minikube | any      | E2E tests only                 |
+| Helm     | ≥ 3      | E2E tests only                 |
+
+Clone the repository and verify the setup:
+
+```bash
+git clone https://github.com/csepulveda/trivy-webhook-aws-security-hub.git
+cd trivy-webhook-aws-security-hub
+make check   # unit tests + docker build
+```
+
+## Making changes
+
+1. Fork the repository and create a branch from `main`:
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+
+2. Make your changes. Keep commits focused — one logical change per commit.
+
+3. Run the full local test gate before pushing:
+   ```bash
+   make check             # unit tests + docker build (required)
+   make integration-test  # webhook binary + mock Security Hub
+   make e2e-test          # full E2E in Minikube
+   ```
+   All three must pass. The same tests run automatically in CI on every PR.
+
+4. Push your branch and open a pull request against `main`. Include in the PR description:
+   - **What** changed and **why**
+   - How you tested it (which test levels you ran)
+   - Any relevant context for reviewers
+
+## Testing levels
+
+### Unit tests
+
+Pure Go tests with no external dependencies:
+
+```bash
+go test ./... -count=1
+```
+
+### Integration tests
+
+Tests the full request lifecycle against a mock Security Hub — no AWS account or external services needed:
+
+```bash
+make integration-test
+# or directly:
+./hack/integration-test.sh
+```
+
+The script compiles and runs a local mock server (`tests/mock-security-hub/`) that implements the real STS and Security Hub HTTP APIs, starts the webhook binary pointing at it, and runs Go integration tests that POST sample reports and assert the findings arrived correctly.
+
+### E2E tests (Minikube)
+
+Full end-to-end inside a real Kubernetes cluster:
+
+```bash
+minikube start --cpus=2 --memory=4096   # skip if already running
+make e2e-test
+# or directly:
+./hack/minikube-e2e.sh
+```
+
+The script verifies Minikube is running, builds both images into Minikube's Docker daemon, deploys the webhook via Helm and the mock Security Hub as a pod, creates sample `VulnerabilityReport` and `ConfigAuditReport` objects, sends them to the webhook, and asserts that all 6 expected findings appear in the mock.
+
+## Code guidelines
+
+- No comments unless the **why** is non-obvious (hidden constraint, subtle invariant, workaround for a specific external bug).
+- No half-finished implementations — if a feature isn't complete, don't merge it.
+- Keep changes minimal and focused. Don't refactor or add abstractions beyond what the task requires.
+
+## Release process (maintainers only)
+
+Releases are fully automated by GitHub Actions. To cut a release:
+
+1. Ensure all changes are merged to `main` and CI is green.
+2. Create and push a semver tag:
+   ```bash
+   git tag v0.1.18
+   git push origin v0.1.18
+   ```
+3. The `release.yml` workflow triggers automatically and:
+   - Builds and pushes the Docker image to `ghcr.io/csepulveda/trivy-webhook-aws-security-hub:<tag>`
+   - Packages the Helm chart (overriding `version` and `appVersion` from the tag) and publishes it to the OCI registry at `ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub`
+   - Creates a GitHub Release via `chart-releaser`
+
+No manual Chart.yaml version bump is needed — the workflow derives the chart version from the git tag at package time.

--- a/charts/trivy-webhook-aws-security-hub/readme.md
+++ b/charts/trivy-webhook-aws-security-hub/readme.md
@@ -44,6 +44,7 @@ Replace `trivy-webhook.default` with `<release-name>.<namespace>` matching your 
 | `config.CONFIG_AUDIT_ENABLE` | Process `ConfigAuditReport` | `"false"` |
 | `config.INFRA_ASSESSMENT_ENABLE` | Process `InfraAssessmentReport` | `"false"` |
 | `config.CLUSTER_COMPLIANCE_ENABLE` | Process `ClusterComplianceReport` | `"false"` |
+| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS account ID — useful in multi-account Security Hub organizations where the same CVE can appear across member accounts | `"false"` |
 
 ### Extra environment variables
 
@@ -58,11 +59,7 @@ extraenvs:
       secretKeyRef:
         name: aws-credentials
         key: secret-access-key
-  - name: INCLUDE_ACCOUNT_ID_IN_FINDING_ID
-    value: "true"
 ```
-
-`INCLUDE_ACCOUNT_ID_IN_FINDING_ID` prefixes finding IDs with the AWS account ID — useful in multi-account Security Hub organizations where the same CVE can appear across member accounts.
 
 ### Common parameters
 

--- a/charts/trivy-webhook-aws-security-hub/readme.md
+++ b/charts/trivy-webhook-aws-security-hub/readme.md
@@ -1,176 +1,156 @@
+# trivy-webhook-aws-security-hub
 
-# Trivy Webhook for AWS Security Hub
-
-This application integrates [Trivy](https://github.com/aquasecurity/trivy), a popular container vulnerability scanning tool, with [AWS Security Hub](https://aws.amazon.com/security-hub/). It acts as a webhook receiver that listens for vulnerability reports sent by Trivy and imports the findings into AWS Security Hub, enabling centralized vulnerability management for container images in your AWS environment.
-
-## Features
-- **Webhook Receiver**: Accepts vulnerability reports in JSON format from Trivy.
-- **AWS Security Hub Integration**: Automatically imports container vulnerabilities as findings into AWS Security Hub.
-- **Seamless Kubernetes Integration**: Works with the Trivy Operator in Kubernetes for automated vulnerability scans.
-
-## Prerequisites
-- AWS account with [Security Hub](https://aws.amazon.com/security-hub/) enabled.
-- Kubernetes cluster with [Trivy Operator](https://github.com/aquasecurity/trivy-operator) installed.
-- [Helm](https://helm.sh/) installed for deployment.
-- IAM role created with access to AWS Security Hub or set the AWS env Variables.
-
-## How to Install
-Add the Helm repository:
-
-```bash
-helm repo add trivy-webhook-aws-security-hub https://csepulveda.github.io/trivy-webhook-aws-security-hub/
-```
-
-Install the Helm chart:
-
-```bash
-helm install trivy-webhook trivy-webhook-aws-security-hub/trivy-webhook-aws-security-hub \
-  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::xxx:role/trivy-webhook-aws-security-hub-role"
-```
-
-- Replace `arn:aws:iam::xxx:role/trivy-webhook-aws-security-hub-role` with your actual IAM role ARN.
-- The IAM role should have permissions to write findings into AWS Security Hub.
-
-### Explanation:
-- The `serviceAccount.annotations` sets the necessary IAM role for the service to access AWS resources securely.
-- By specifying `eks.amazonaws.com/role-arn`, the Trivy webhook can assume the specified IAM role and import vulnerability findings into Security Hub.
-
-## ⚙️ Configuration
-
-All configuration is done via `values.yaml` or `--set` in the Helm CLI.
-
-### Common Parameters
-
-| Name                      | Description                                                   | Type      | Default   |
-|--------------------------|---------------------------------------------------------------|-----------|-----------|
-| `replicaCount`            | Number of trivy-webhook replicas                             | `integer` | `1`       |
-| `image.repository`        | Docker image repository                                      | `string`  | `ghcr.io/csepulveda/trivy-webhook-aws-security-hub` |
-| `image.pullPolicy`        | Image pull policy                                            | `string`  | `IfNotPresent` |
-| `image.tag`               | Image tag (defaults to chart's AppVersion)                   | `string`  | `""`      |
-| `imagePullSecrets`        | List of image pull secrets                                   | `list`    | `[]`      |
-| `nameOverride`            | Override for the release name                                | `string`  | `""`      |
-| `fullnameOverride`        | Override for full release name                               | `string`  | `""`      |
-
----
-
-### App Configuration (`config` block)
-
-| Name                                | Description                                        | Default          |
-|-------------------------------------|--------------------------------------------------|------------------|
-| `config.AWS_REGION`                  | AWS region for Security Hub                      | `eu-central-1`   |
-| `config.INFRA_ASSESSMENT_ENABLE`     | Enable Infra Assessment report processing        | `"false"`         |
-| `config.CONFIG_AUDIT_ENABLE`         | Enable Config Audit report processing            | `"false"`         |
-| `config.CLUSTER_COMPLIANCE_ENABLE`  | Enable Cluster Compliance report processing     | `"false"`         |
-| `config.VULNERABILITY_ENABLE`        | Enable Vulnerability report processing           | `"true"`         |
-
-> These environment variables control what types of Trivy reports are processed and sent to AWS Security Hub.
-
----
-
-### Extra Environment Variables
-
-| Name             | Description                                | Type  | Default |
-|------------------|--------------------------------------------|-------|---------|
-| `extraenvs`      | List of additional environment variables   | `list`| `[]`    |
-
----
-
-### Kubernetes & Pod Settings
-
-| Name                      | Description                                                   | Type     | Default   |
-|--------------------------|---------------------------------------------------------------|----------|-----------|
-| `serviceAccount.create`   | Whether to create a ServiceAccount                           | `bool`   | `true`    |
-| `serviceAccount.automount`| Auto-mount API credentials                                    | `bool`   | `true`    |
-| `serviceAccount.annotations`| Annotations for the ServiceAccount                         | `object` | `{}`      |
-| `serviceAccount.name`     | Name of the ServiceAccount (auto-generated if empty)         | `string` | `""`      |
-| `podAnnotations`          | Pod annotations                                               | `object` | `{}`      |
-| `podLabels`               | Pod labels                                                    | `object` | `{}`      |
-| `podSecurityContext`      | Security context for pod                                      | `object` | `{}`      |
-| `securityContext`         | Security context for container                               | `object` | `{}`      |
-| `nodeSelector`            | Node selector for pod scheduling                             | `object` | `{}`      |
-| `tolerations`             | Tolerations for pod scheduling                               | `list`   | `[]`      |
-| `affinity`                | Affinity rules for pod scheduling                            | `object` | `{}`      |
-
----
-
-### Service
-
-| Name             | Description                                | Type   | Default   |
-|------------------|--------------------------------------------|--------|-----------|
-| `service.type`   | Kubernetes service type                    | `string`| `ClusterIP`|
-| `service.port`   | Service port                               | `int`  | `80`      |
-
----
-
-### Resources
-
-| Name                   | Description                          | Type   | Default  |
-|-----------------------|--------------------------------------|--------|----------|
-| `resources.limits`     | Resource limits                      | `object`| `{}`    |
-| `resources.requests`   | Resource requests                    | `object`| `{}`    |
-
----
-
-### Probes
-
-| Name                                 | Description                      | Type   | Default   |
-|--------------------------------------|----------------------------------|--------|-----------|
-| `livenessProbe.httpGet.path`          | Path for liveness probe          | `string`| `/healthz`|
-| `livenessProbe.httpGet.port`          | Port for liveness probe          | `string`| `http`    |
-| `readinessProbe.httpGet.path`         | Path for readiness probe         | `string`| `/healthz`|
-| `readinessProbe.httpGet.port`         | Port for readiness probe         | `string`| `http`    |
-
----
-
-### Autoscaling
-
-| Name                                         | Description                          | Type    | Default |
-|----------------------------------------------|--------------------------------------|---------|---------|
-| `autoscaling.enabled`                        | Enable autoscaling                   | `bool`  | `false` |
-| `autoscaling.minReplicas`                    | Minimum replicas                     | `int`   | `1`     |
-| `autoscaling.maxReplicas`                    | Maximum replicas                     | `int`   | `2`     |
-| `autoscaling.targetCPUUtilizationPercentage` | CPU target percentage                | `int`   | `80`    |
-
----
-
-### Volumes and Mounts
-
-| Name             | Description                                | Type  | Default |
-|------------------|--------------------------------------------|-------|---------|
-| `volumes`        | Additional volumes to mount                | `list`| `[]`    |
-| `volumeMounts`   | Additional volume mounts for containers    | `list`| `[]`    |
-
-## Setting Up Trivy Operator
-
-To send vulnerability reports from the Trivy Operator to the webhook, configure the following setting in the `trivy-operator` Helm chart:
-
-```bash
---set operator.webhookBroadcastURL=http://<service-name>.<namespace>/trivy-webhook
-```
-
-Example:
-
-```bash
---set operator.webhookBroadcastURL=http://trivy-webhook-aws-security-hub.default/trivy-webhook
-```
-
-This ensures that the Trivy Operator sends its scan results to the Trivy webhook, which will then process and forward them to AWS Security Hub.
+A webhook receiver that processes security reports from [Trivy Operator](https://github.com/aquasecurity/trivy-operator) and imports the findings into [AWS Security Hub](https://aws.amazon.com/security-hub/).
 
 ## How It Works
 
-1. **Trivy Scan**: Trivy scans container images for vulnerabilities.
-2. **Webhook**: The Trivy Operator sends the scan report to the Trivy Webhook via the `/trivy-webhook` endpoint.
-3. **AWS Security Hub**: The webhook processes the report and imports the findings into AWS Security Hub, enabling centralized vulnerability management.
+1. Trivy Operator scans workloads and generates reports (`VulnerabilityReport`, `ConfigAuditReport`, `InfraAssessmentReport`, `ClusterComplianceReport`).
+2. Trivy Operator calls this webhook's `/trivy-webhook` endpoint with the report payload.
+3. The webhook maps each finding to the [AWS Security Finding Format (ASFF)](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html) and imports it via `BatchImportFindings`.
 
-## Customization
+## Prerequisites
 
-You can customize various parameters of the Helm chart, such as:
-- **ServiceAccount annotations** for IAM role-based access.
-- **Replicas** to scale the webhook deployment.
-- **Resource requests and limits** for container sizing.
+- AWS account with [Security Hub](https://aws.amazon.com/security-hub/) enabled.
+- The **Aqua Security** product integration accepted in Security Hub (`Aqua Security: Aqua Security`).
+- Kubernetes cluster with [Trivy Operator](https://github.com/aquasecurity/trivy-operator) installed.
+- [Helm](https://helm.sh/) ≥ 3.
+- IAM role or access keys with `securityhub:BatchImportFindings` permission.
 
-For a full list of configurable values, refer to the `values.yaml` file in the Helm chart.
+## Installation
+
+```bash
+helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
+  --set config.AWS_REGION=eu-central-1 \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
+```
+
+Then point Trivy Operator at the webhook:
+
+```bash
+helm upgrade trivy-operator aquasecurity/trivy-operator \
+  --set operator.webhookBroadcastURL=http://trivy-webhook.default/trivy-webhook
+```
+
+Replace `trivy-webhook.default` with `<release-name>.<namespace>` matching your installation.
+
+## Configuration
+
+### App settings (`config` block)
+
+| Parameter | Description | Default |
+|---|---|---|
+| `config.AWS_REGION` | AWS region where Security Hub is enabled | `eu-central-1` |
+| `config.VULNERABILITY_ENABLE` | Process `VulnerabilityReport` | `"true"` |
+| `config.CONFIG_AUDIT_ENABLE` | Process `ConfigAuditReport` | `"false"` |
+| `config.INFRA_ASSESSMENT_ENABLE` | Process `InfraAssessmentReport` | `"false"` |
+| `config.CLUSTER_COMPLIANCE_ENABLE` | Process `ClusterComplianceReport` | `"false"` |
+
+### Extra environment variables
+
+Use `extraenvs` to pass additional env vars (e.g. static credentials or endpoint overrides):
+
+```yaml
+extraenvs:
+  - name: AWS_ACCESS_KEY_ID
+    value: AKIAIOSFODNN7EXAMPLE
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: aws-credentials
+        key: secret-access-key
+  - name: INCLUDE_ACCOUNT_ID_IN_FINDING_ID
+    value: "true"
+```
+
+`INCLUDE_ACCOUNT_ID_IN_FINDING_ID` prefixes finding IDs with the AWS account ID — useful in multi-account Security Hub organizations where the same CVE can appear across member accounts.
+
+### Common parameters
+
+| Parameter | Description | Default |
+|---|---|---|
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | Docker image repository | `ghcr.io/csepulveda/trivy-webhook-aws-security-hub` |
+| `image.tag` | Image tag (defaults to chart `appVersion`) | `""` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `nameOverride` | Override release name | `""` |
+| `fullnameOverride` | Override full release name | `""` |
+| `imagePullSecrets` | List of image pull secrets | `[]` |
+
+### Service account
+
+| Parameter | Description | Default |
+|---|---|---|
+| `serviceAccount.create` | Create a ServiceAccount | `true` |
+| `serviceAccount.automount` | Auto-mount API credentials | `true` |
+| `serviceAccount.annotations` | Annotations (e.g. IRSA role ARN) | `{}` |
+| `serviceAccount.name` | Name (auto-generated if empty) | `""` |
+
+### Pod settings
+
+| Parameter | Description | Default |
+|---|---|---|
+| `podAnnotations` | Extra pod annotations | `{}` |
+| `podLabels` | Extra pod labels | `{}` |
+| `podSecurityContext` | Pod-level security context | `{}` |
+| `securityContext` | Container-level security context | `{}` |
+| `resources.limits` | Container resource limits | `{}` |
+| `resources.requests` | Container resource requests | `{}` |
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Tolerations | `[]` |
+| `affinity` | Affinity rules | `{}` |
+| `volumes` | Additional volumes | `[]` |
+| `volumeMounts` | Additional volume mounts | `[]` |
+
+### Service
+
+| Parameter | Description | Default |
+|---|---|---|
+| `service.type` | Kubernetes service type | `ClusterIP` |
+| `service.port` | Service port | `80` |
+
+### Probes
+
+| Parameter | Description | Default |
+|---|---|---|
+| `livenessProbe.httpGet.path` | Liveness probe path | `/healthz` |
+| `livenessProbe.httpGet.port` | Liveness probe port | `http` |
+| `readinessProbe.httpGet.path` | Readiness probe path | `/healthz` |
+| `readinessProbe.httpGet.port` | Readiness probe port | `http` |
+
+### Autoscaling
+
+| Parameter | Description | Default |
+|---|---|---|
+| `autoscaling.enabled` | Enable HPA | `false` |
+| `autoscaling.minReplicas` | Minimum replicas | `1` |
+| `autoscaling.maxReplicas` | Maximum replicas | `2` |
+| `autoscaling.targetCPUUtilizationPercentage` | CPU target | `80` |
+
+## IAM permissions
+
+Minimum IAM policy required:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "securityhub:BatchImportFindings",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+The recommended approach is to use [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IAM Roles for Service Accounts) via `serviceAccount.annotations`:
+
+```bash
+helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
+  --set config.AWS_REGION=eu-central-1 \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
+```
 
 ## License
 
-This project is licensed under the GNU General Public License v3.0.
+Licensed under the [GNU General Public License v3.0](https://github.com/csepulveda/trivy-webhook-aws-security-hub/blob/main/LICENSE).

--- a/charts/trivy-webhook-aws-security-hub/templates/deployment.yaml
+++ b/charts/trivy-webhook-aws-security-hub/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
               value: {{ .Values.config.CLUSTER_COMPLIANCE_ENABLE | quote }}
             - name: VULNERABILITY_ENABLE
               value: {{ .Values.config.VULNERABILITY_ENABLE | quote }}
+            - name: INCLUDE_ACCOUNT_ID_IN_FINDING_ID
+              value: {{ .Values.config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID | quote }}
             {{ if .Values.extraenvs }}
               {{- toYaml .Values.extraenvs | nindent 12 }}
             {{- end }}

--- a/charts/trivy-webhook-aws-security-hub/values.yaml
+++ b/charts/trivy-webhook-aws-security-hub/values.yaml
@@ -33,12 +33,14 @@ fullnameOverride: ""
 ## @description config.CONFIG_AUDIT_ENABLE: Enable configuration audit.
 ## @description config.CLUSTER_COMPLIANCE_ENABLE: Enable cluster compliance.
 ## @description config.VULNERABILITY_ENABLE: Enable vulnerability assessment.
+## @description config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID: Prefix finding IDs with the AWS account ID (useful in multi-account Security Hub orgs).
 config:
   AWS_REGION: eu-central-1
   INFRA_ASSESSMENT_ENABLE: false
   CONFIG_AUDIT_ENABLE: false
   CLUSTER_COMPLIANCE_ENABLE: false
   VULNERABILITY_ENABLE: true
+  INCLUDE_ACCOUNT_ID_IN_FINDING_ID: false
 
 ## @param extraenvs [array] Extra environment variables to set for the trivy-webhook container.
 ## @description Extra environment variables to set for the trivy-webhook container.


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — new file covering dev setup, all three testing levels (unit / integration / E2E), PR workflow, and the maintainer release process (push a `vX.Y.Z` tag, automation handles the rest)
- **Chart readme** — rewritten: OCI install command, complete config table including `INCLUDE_ACCOUNT_ID_IN_FINDING_ID`, IAM permissions section, accurate defaults for all report-type flags
- **values.yaml** — added `INCLUDE_ACCOUNT_ID_IN_FINDING_ID: false` to the `config` block
- **deployment.yaml** — wired `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` into the container env (was missing from the template)

## Test plan

- [ ] CI passes (unit tests + docker build + integration + E2E)
- [ ] After merge: push tag `v0.1.18` and verify the release workflow builds the image and publishes the Helm chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with clearer installation instructions, prerequisites, and IAM policy requirements for AWS Security Hub integration.

* **New Features**
  * Added configuration option to include AWS account ID in finding IDs, supporting multi-account AWS Security Hub scenarios.

* **Chores**
  * Added contributor guide documenting development tooling, testing requirements, and release procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->