### PR TITLE
feat: add CLUSTER_NAME support and deployment scenario docs

### DIFF
--- a/charts/trivy-webhook-aws-security-hub/readme.md
+++ b/charts/trivy-webhook-aws-security-hub/readme.md
@@ -49,7 +49,7 @@ Replace `trivy-webhook.default` with `<release-name>.<namespace>` matching your 
 | `config.CONFIG_AUDIT_ENABLE` | Process `ConfigAuditReport` | `"false"` |
 | `config.INFRA_ASSESSMENT_ENABLE` | Process `InfraAssessmentReport` | `"false"` |
 | `config.CLUSTER_COMPLIANCE_ENABLE` | Process `ClusterComplianceReport` | `"false"` |
-| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS account ID — recommended in multi-account Security Hub organizations | `"false"` |
+| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS account ID. Supported but not recommended — when using the AWS Organizations integration, the delegated administrator account already shows `AwsAccountId` and region natively for every finding | `"false"` |
 | `config.CLUSTER_NAME` | Cluster identifier included in finding IDs and `ProductFields` — required when multiple clusters share the same account to prevent finding ID collisions | `""` |
 
 ### Extra environment variables

--- a/charts/trivy-webhook-aws-security-hub/readme.md
+++ b/charts/trivy-webhook-aws-security-hub/readme.md
@@ -11,10 +11,15 @@ A webhook receiver that processes security reports from [Trivy Operator](https:/
 ## Prerequisites
 
 - AWS account with [Security Hub](https://aws.amazon.com/security-hub/) enabled.
-- The **Aqua Security** product integration accepted in Security Hub (`Aqua Security: Aqua Security`).
+- The **Aqua Security** product integration enabled in Security Hub — **must be done before deploying**, otherwise all imports will fail with `AccessDeniedException`:
+  ```bash
+  aws securityhub enable-import-findings-for-product \
+    --product-arn arn:aws:securityhub:<region>::product/aquasecurity/aquasecurity \
+    --region <region>
+  ```
 - Kubernetes cluster with [Trivy Operator](https://github.com/aquasecurity/trivy-operator) installed.
 - [Helm](https://helm.sh/) ≥ 3.
-- IAM role or access keys with `securityhub:BatchImportFindings` permission.
+- IAM role with `securityhub:BatchImportFindings` permission, associated via [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 
 ## Installation
 
@@ -44,7 +49,8 @@ Replace `trivy-webhook.default` with `<release-name>.<namespace>` matching your 
 | `config.CONFIG_AUDIT_ENABLE` | Process `ConfigAuditReport` | `"false"` |
 | `config.INFRA_ASSESSMENT_ENABLE` | Process `InfraAssessmentReport` | `"false"` |
 | `config.CLUSTER_COMPLIANCE_ENABLE` | Process `ClusterComplianceReport` | `"false"` |
-| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS account ID — useful in multi-account Security Hub organizations where the same CVE can appear across member accounts | `"false"` |
+| `config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS account ID — recommended in multi-account Security Hub organizations | `"false"` |
+| `config.CLUSTER_NAME` | Cluster identifier included in finding IDs and `ProductFields` — required when multiple clusters share the same account to prevent finding ID collisions | `""` |
 
 ### Extra environment variables
 

--- a/charts/trivy-webhook-aws-security-hub/templates/deployment.yaml
+++ b/charts/trivy-webhook-aws-security-hub/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: {{ .Values.config.VULNERABILITY_ENABLE | quote }}
             - name: INCLUDE_ACCOUNT_ID_IN_FINDING_ID
               value: {{ .Values.config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID | quote }}
+            - name: CLUSTER_NAME
+              value: {{ .Values.config.CLUSTER_NAME | quote }}
             {{ if .Values.extraenvs }}
               {{- toYaml .Values.extraenvs | nindent 12 }}
             {{- end }}

--- a/charts/trivy-webhook-aws-security-hub/values.yaml
+++ b/charts/trivy-webhook-aws-security-hub/values.yaml
@@ -34,6 +34,7 @@ fullnameOverride: ""
 ## @description config.CLUSTER_COMPLIANCE_ENABLE: Enable cluster compliance.
 ## @description config.VULNERABILITY_ENABLE: Enable vulnerability assessment.
 ## @description config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID: Prefix finding IDs with the AWS account ID (useful in multi-account Security Hub orgs).
+## @description config.CLUSTER_NAME: Cluster identifier included in finding IDs and ProductFields. Required when multiple clusters share the same account to prevent finding ID collisions.
 config:
   AWS_REGION: eu-central-1
   INFRA_ASSESSMENT_ENABLE: false
@@ -41,6 +42,7 @@ config:
   CLUSTER_COMPLIANCE_ENABLE: false
   VULNERABILITY_ENABLE: true
   INCLUDE_ACCOUNT_ID_IN_FINDING_ID: false
+  CLUSTER_NAME: ""
 
 ## @param extraenvs [array] Extra environment variables to set for the trivy-webhook container.
 ## @description Extra environment variables to set for the trivy-webhook container.

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ type Config struct {
 	ClusterComplianceEnable     bool
 	VulnerabilityEnable         bool
 	IncludeAccountIDInFindingID bool
+	ClusterName                 string
 }
 
 // LoadConfig reads feature flags from environment variables.
@@ -43,6 +44,7 @@ func LoadConfig() Config {
 		ClusterComplianceEnable:     tools.ParseEnvBool("CLUSTER_COMPLIANCE_ENABLE", true),
 		VulnerabilityEnable:         tools.ParseEnvBool("VULNERABILITY_ENABLE", true),
 		IncludeAccountIDInFindingID: tools.ParseEnvBool("INCLUDE_ACCOUNT_ID_IN_FINDING_ID", false),
+		ClusterName:                 os.Getenv("CLUSTER_NAME"),
 	}
 }
 
@@ -190,6 +192,14 @@ func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecuri
 		if appCfg.IncludeAccountIDInFindingID {
 			findingID = fmt.Sprintf("%s-%s-%s", AWSAccountID, check.ID, Name)
 		}
+		if appCfg.ClusterName != "" {
+			findingID = appCfg.ClusterName + "-" + findingID
+		}
+
+		productFields := map[string]string{"Product Name": "Trivy"}
+		if appCfg.ClusterName != "" {
+			productFields["ClusterName"] = appCfg.ClusterName
+		}
 
 		findings = append(findings, types.AwsSecurityFinding{
 			SchemaVersion: aws.String("2018-10-08"),
@@ -208,7 +218,7 @@ func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecuri
 					Text: aws.String(check.Remediation),
 				},
 			},
-			ProductFields: map[string]string{"Product Name": "Trivy"},
+			ProductFields: productFields,
 			Resources: []types.Resource{
 				{
 					Type:      aws.String("Other"),
@@ -304,10 +314,10 @@ func getVulnerabilityReportFindings(body []byte, appCfg Config) ([]types.AwsSecu
 	AWSAccountID := aws.ToString(callerIdentity.Account)
 	AWSRegion := cfg.Region
 
-	return buildVulnerabilityReportFindings(vulnerabilityReport, AWSAccountID, AWSRegion, appCfg.IncludeAccountIDInFindingID), nil
+	return buildVulnerabilityReportFindings(vulnerabilityReport, AWSAccountID, AWSRegion, appCfg.IncludeAccountIDInFindingID, appCfg.ClusterName), nil
 }
 
-func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.VulnerabilityReport, AWSAccountID string, AWSRegion string, includeAccountID bool) []types.AwsSecurityFinding {
+func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.VulnerabilityReport, AWSAccountID string, AWSRegion string, includeAccountID bool, clusterName string) []types.AwsSecurityFinding {
 	ProductArn := fmt.Sprintf("arn:aws:securityhub:%s::product/aquasecurity/aquasecurity", AWSRegion)
 	Namespace := vulnerabilityReport.Namespace
 	ReportName := vulnerabilityReport.Name
@@ -348,6 +358,9 @@ func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.Vulnerabilit
 		if includeAccountID {
 			rawFindingID = fmt.Sprintf("%s-%s-%s-%s", AWSAccountID, Namespace, FullImageName, vulnerabilities.VulnerabilityID)
 		}
+		if clusterName != "" {
+			rawFindingID = clusterName + "-" + rawFindingID
+		}
 		findingID := truncateWithHash(rawFindingID, 512)
 		title := truncateWithHash(fmt.Sprintf("%s/%s/%s:%s %s", Namespace, ImageName, Container, Tag, vulnerabilities.VulnerabilityID), 256)
 		resourceID := truncateWithHash(fmt.Sprintf("%s/%s", Namespace, ImageName), 512)
@@ -370,10 +383,16 @@ func buildVulnerabilityReportFindings(vulnerabilityReport *v1alpha1.Vulnerabilit
 					Url:  aws.String(vulnerabilities.PrimaryLink),
 				},
 			},
-			ProductFields: map[string]string{
-				"Product Name": "Trivy",
-				"Namespace":    Namespace,
-			},
+			ProductFields: func() map[string]string {
+				pf := map[string]string{
+					"Product Name": "Trivy",
+					"Namespace":    Namespace,
+				}
+				if clusterName != "" {
+					pf["ClusterName"] = clusterName
+				}
+				return pf
+			}(),
 			Resources: []types.Resource{
 				{
 					Type:      aws.String("Container"),

--- a/main_test.go
+++ b/main_test.go
@@ -43,7 +43,7 @@ func TestBuildVulnerabilityReportFindingsIncludesNamespace(t *testing.T) {
 		},
 	}
 
-	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false)
+	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false, "")
 
 	require.Len(t, findings, 1)
 
@@ -90,7 +90,7 @@ func TestBuildVulnerabilityReportFindingsTruncatesSecurityHubFields(t *testing.T
 		},
 	}
 
-	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false)
+	findings := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false, "")
 
 	require.Len(t, findings, 1)
 	assert.LessOrEqual(t, len([]rune(aws.ToString(findings[0].Id))), 512)
@@ -115,12 +115,43 @@ func TestBuildVulnerabilityReportFindingsIncludesAccountID(t *testing.T) {
 		},
 	}
 
-	withoutAccount := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false)
-	withAccount := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", true)
+	withoutAccount := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false, "")
+	withAccount := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", true, "")
 
 	require.Len(t, withAccount, 1)
 	assert.Contains(t, aws.ToString(withAccount[0].Id), "123456789012-")
 	assert.NotContains(t, aws.ToString(withoutAccount[0].Id), "123456789012-")
+}
+
+func TestBuildVulnerabilityReportFindingsClusterName(t *testing.T) {
+	report := &v1alpha1.VulnerabilityReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "replicaset-nginx-7c9d",
+			Namespace: "payments",
+			Labels:    map[string]string{"trivy-operator.container.name": "nginx"},
+		},
+		Report: v1alpha1.VulnerabilityReportData{
+			Registry: v1alpha1.Registry{Server: "docker.io"},
+			Artifact: v1alpha1.Artifact{Repository: "library/nginx", Tag: "1.25.0"},
+			Vulnerabilities: []v1alpha1.Vulnerability{
+				{VulnerabilityID: "CVE-2026-0001", Severity: v1alpha1.SeverityHigh, Title: "test"},
+			},
+		},
+	}
+
+	withCluster := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false, "prod-cluster")
+	withoutCluster := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false, "")
+
+	require.Len(t, withCluster, 1)
+	assert.Contains(t, aws.ToString(withCluster[0].Id), "prod-cluster-")
+	assert.Equal(t, "prod-cluster", withCluster[0].ProductFields["ClusterName"])
+
+	assert.NotContains(t, aws.ToString(withoutCluster[0].Id), "prod-cluster-")
+	assert.Empty(t, withoutCluster[0].ProductFields["ClusterName"])
+
+	// findings from two clusters for the same CVE must have different IDs
+	devCluster := buildVulnerabilityReportFindings(report, "123456789012", "eu-central-1", false, "dev-cluster")
+	assert.NotEqual(t, aws.ToString(withCluster[0].Id), aws.ToString(devCluster[0].Id))
 }
 
 func TestTruncateWithHash(t *testing.T) {

--- a/readme.md
+++ b/readme.md
@@ -12,9 +12,129 @@ A webhook receiver that processes security reports from [Trivy Operator](https:/
 ## Prerequisites
 
 - An AWS account with Security Hub enabled
-- The **Aqua Security** product integration accepted in Security Hub (`Aqua Security: Aqua Security`)
-- AWS credentials with `securityhub:BatchImportFindings` permission
+- The **Aqua Security** product integration enabled in Security Hub — **this must be done before deploying the webhook**, otherwise all imports will fail with `AccessDeniedException`:
+  ```bash
+  aws securityhub enable-import-findings-for-product \
+    --product-arn arn:aws:securityhub:<region>::product/aquasecurity/aquasecurity \
+    --region <region>
+  ```
+- An IAM role with `securityhub:BatchImportFindings` permission, associated to the webhook pod via [IRSA](#iam-setup-irsa)
 - Trivy Operator installed in your Kubernetes cluster
+
+## Deployment Scenarios
+
+### Single account, single cluster
+
+The simplest setup. The webhook sends findings directly to Security Hub in the same account and region where the cluster runs.
+
+```
+EKS Cluster ──→ Security Hub (same account, same region)
+```
+
+No additional configuration needed beyond the prerequisites. `CLUSTER_NAME` is optional.
+
+```bash
+helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
+  --set config.AWS_REGION=us-east-1 \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
+```
+
+---
+
+### Single account, multiple clusters
+
+When multiple clusters share the same account, the same CVE in the same workload produces identical finding IDs — Security Hub uses the `Id` field as a deduplication key, so findings from different clusters overwrite each other.
+
+**Set `CLUSTER_NAME` on each deployment** to make finding IDs unique and traceable to their origin:
+
+```
+EKS Cluster dev  ──→ Security Hub (account 123456789012)
+EKS Cluster prod ──→ Security Hub (account 123456789012)
+```
+
+```bash
+# dev cluster
+helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
+  --set config.AWS_REGION=us-east-1 \
+  --set config.CLUSTER_NAME=dev \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
+
+# prod cluster
+helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
+  --set config.AWS_REGION=us-east-1 \
+  --set config.CLUSTER_NAME=prod \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
+```
+
+`CLUSTER_NAME` is included in the finding `Id` and in `ProductFields`, so you can filter findings by cluster in Security Hub.
+
+---
+
+### Multi-account, multiple clusters with Security Hub Organizations
+
+The recommended architecture for organizations with multiple AWS accounts. Each webhook instance sends findings to **its own account's Security Hub** — never cross-account. AWS Organizations handles the aggregation centrally.
+
+```
+Account A / Cluster A ──→ Security Hub (Account A)  ──┐
+Account B / Cluster B ──→ Security Hub (Account B)  ──┤──→ Security Hub Delegated Admin
+Account C / Cluster C ──→ Security Hub (Account C)  ──┘     (central visibility)
+```
+
+Each account must have the Aqua Security product enabled (see Prerequisites). Enable `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` so findings carrying the same CVE from different accounts remain distinct in the aggregated view:
+
+```bash
+helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
+  --set config.AWS_REGION=us-east-1 \
+  --set config.CLUSTER_NAME=prod-cluster \
+  --set config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID=true \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
+```
+
+**Security Hub Organizations setup** (one-time, run from the management account):
+
+```bash
+# Designate a delegated administrator for Security Hub
+aws securityhub enable-organization-admin-account \
+  --admin-account-id <central-security-account-id>
+
+# From the delegated admin account, enable auto-enrollment for new member accounts
+aws securityhub update-organization-configuration \
+  --auto-enable \
+  --auto-enable-standards DEFAULT
+```
+
+See the [AWS Security Hub Organizations documentation](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-accounts-orgs.html) for the full setup guide.
+
+---
+
+## IAM Setup (IRSA)
+
+Create an IAM role with the following minimum policy and associate it to the webhook's service account via IRSA:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "securityhub:BatchImportFindings",
+    "Resource": "*"
+  }]
+}
+```
+
+```bash
+# 1. Associate the OIDC provider with your cluster (if not already done)
+eksctl utils associate-iam-oidc-provider \
+  --cluster <cluster-name> --region <region> --approve
+
+# 2. Create the IAM role with the appropriate trust policy for your cluster's OIDC provider
+#    (see https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html)
+
+# 3. Deploy the webhook referencing that role
+helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
+  --set config.AWS_REGION=<region> \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<account-id>:role/<role-name>
+```
 
 ## Environment Variables
 
@@ -24,7 +144,8 @@ A webhook receiver that processes security reports from [Trivy Operator](https:/
 | `CONFIG_AUDIT_ENABLE` | Process `ConfigAuditReport` | `true` |
 | `INFRA_ASSESSMENT_ENABLE` | Process `InfraAssessmentReport` | `true` |
 | `CLUSTER_COMPLIANCE_ENABLE` | Process `ClusterComplianceReport` | `true` |
-| `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS Account ID — useful in multi-account Security Hub organizations where the same CVE can appear across member accounts | `false` |
+| `CLUSTER_NAME` | Cluster identifier included in finding IDs and `ProductFields` — required when multiple clusters share the same account to prevent finding ID collisions | `""` |
+| `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS Account ID — recommended in multi-account Security Hub organizations | `false` |
 | `AWS_REGION` | AWS region where Security Hub is enabled | — |
 | `AWS_ACCESS_KEY_ID` | AWS access key (standard SDK env var) | — |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key (standard SDK env var) | — |
@@ -35,16 +156,6 @@ A webhook receiver that processes security reports from [Trivy Operator](https:/
 |---|---|---|
 | `POST` | `/trivy-webhook` | Receives Trivy Operator report payloads |
 | `GET` | `/healthz` | Health check — returns `OK` |
-
-## Deploy with Helm
-
-```bash
-helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
-  --set config.AWS_REGION=eu-central-1 \
-  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
-```
-
-Full values reference: [`charts/trivy-webhook-aws-security-hub/values.yaml`](charts/trivy-webhook-aws-security-hub/values.yaml)
 
 ## Development
 

--- a/readme.md
+++ b/readme.md
@@ -70,40 +70,43 @@ helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-sec
 
 ---
 
-### Multi-account, multiple clusters with Security Hub Organizations
+### Multi-account, multiple clusters with AWS Organizations integration
 
-The recommended architecture for organizations with multiple AWS accounts. Each webhook instance sends findings to **its own account's Security Hub** — never cross-account. AWS Organizations handles the aggregation centrally.
+The recommended architecture for organizations with multiple AWS accounts. Each webhook instance sends findings to **its own account's Security Hub** — never cross-account. The AWS Organizations integration with a delegated administrator account handles aggregation centrally.
 
 ```
 Account A / Cluster A ──→ Security Hub (Account A)  ──┐
-Account B / Cluster B ──→ Security Hub (Account B)  ──┤──→ Security Hub Delegated Admin
+Account B / Cluster B ──→ Security Hub (Account B)  ──┤──→ Delegated administrator account
 Account C / Cluster C ──→ Security Hub (Account C)  ──┘     (central visibility)
 ```
 
-Each account must have the Aqua Security product enabled (see Prerequisites). Enable `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` so findings carrying the same CVE from different accounts remain distinct in the aggregated view:
+Each account must have the Aqua Security product enabled (see Prerequisites). The delegated administrator account natively shows the `AwsAccountId` and region of every finding, so **`INCLUDE_ACCOUNT_ID_IN_FINDING_ID` is not needed** in this setup. Use `CLUSTER_NAME` if multiple clusters exist within the same account:
 
 ```bash
 helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-security-hub \
   --set config.AWS_REGION=us-east-1 \
   --set config.CLUSTER_NAME=prod-cluster \
-  --set config.INCLUDE_ACCOUNT_ID_IN_FINDING_ID=true \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/trivy-webhook
 ```
 
-**Security Hub Organizations setup** (one-time, run from the management account):
+**AWS Organizations integration setup** (one-time, run from the management account):
 
 ```bash
-# Designate a delegated administrator for Security Hub
+# Designate a delegated administrator account for Security Hub
 aws securityhub enable-organization-admin-account \
-  --admin-account-id <central-security-account-id>
+  --admin-account-id <delegated-administrator-account-id>
 
-# From the delegated admin account, enable auto-enrollment for new member accounts
+# From the delegated administrator account, enable auto-enrollment for new member accounts
 aws securityhub update-organization-configuration \
   --auto-enable \
   --auto-enable-standards DEFAULT
+
+# Optionally configure a finding aggregator to consolidate findings across regions
+aws securityhub create-finding-aggregator \
+  --region-linking-type ALL_REGIONS
 ```
 
-See the [AWS Security Hub Organizations documentation](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-accounts-orgs.html) for the full setup guide.
+See the [AWS Security Hub with AWS Organizations documentation](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-accounts-orgs.html) for the full setup guide.
 
 ---
 
@@ -145,7 +148,7 @@ helm install trivy-webhook oci://ghcr.io/csepulveda/charts/trivy-webhook-aws-sec
 | `INFRA_ASSESSMENT_ENABLE` | Process `InfraAssessmentReport` | `true` |
 | `CLUSTER_COMPLIANCE_ENABLE` | Process `ClusterComplianceReport` | `true` |
 | `CLUSTER_NAME` | Cluster identifier included in finding IDs and `ProductFields` — required when multiple clusters share the same account to prevent finding ID collisions | `""` |
-| `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS Account ID — recommended in multi-account Security Hub organizations | `false` |
+| `INCLUDE_ACCOUNT_ID_IN_FINDING_ID` | Prefix finding IDs with the AWS Account ID. Supported but not recommended — when using the AWS Organizations integration, the delegated administrator account already shows `AwsAccountId` and region natively for every finding | `false` |
 | `AWS_REGION` | AWS region where Security Hub is enabled | — |
 | `AWS_ACCESS_KEY_ID` | AWS access key (standard SDK env var) | — |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key (standard SDK env var) | — |


### PR DESCRIPTION
## Summary

- **`CLUSTER_NAME` env var** — new optional config (default `""`). When set, it's prepended to finding IDs and added to `ProductFields`. Prevents finding ID collisions when multiple clusters share the same AWS account. Fully backward compatible — existing deployments without it behave exactly as before.
- **Unit test** — `TestBuildVulnerabilityReportFindingsClusterName` verifies that two clusters with the same CVE produce different finding IDs and that `ProductFields["ClusterName"]` is set correctly.
- **Chart** — `config.CLUSTER_NAME: ""` added to `values.yaml` and wired through `deployment.yaml`.
- **README** — rewritten deployment section covering three scenarios: single account/cluster, multi-cluster same account, multi-account with Security Hub Organizations.
- **Prerequisite warning** — both root README and chart README now prominently document that the Aqua Security product integration must be enabled before deploying (missing this causes `AccessDeniedException` on every import).

## Test plan

- [x] `go test ./... -count=1` passes (5 unit tests, including new cluster name test)
- [ ] CI passes (unit tests + docker build + integration + E2E)
- [ ] After merge: tag `v0.1.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `CLUSTER_NAME` configuration parameter to support multi-cluster deployments and prevent finding ID collisions across clusters.

* **Documentation**
  * Updated prerequisites to explicitly require Security Hub import setup for Aqua Security product.
  * Added IRSA-based IAM configuration guidance with required policies.
  * Added deployment scenarios documentation covering single-account, multi-cluster, and multi-account setups.
  * Updated environment variables reference to include new `CLUSTER_NAME` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->