### PR TITLE
fix: config audit panics, sequential CI, native ARM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   unit-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,8 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 jobs:
-  # ── Job 1: unit tests ────────────────────────────────────────────────────────
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -24,16 +20,16 @@ jobs:
       - name: Run unit tests
         run: go test ./... -count=1 -v
 
-  # ── Job 2: docker build ──────────────────────────────────────────────────────
   docker-build:
     name: Docker build
+    needs: unit-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Build image
+      - name: Build image (amd64, no push)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -42,11 +38,9 @@ jobs:
           provenance: false
           tags: trivy-webhook-aws-security-hub:ci
 
-  # ── Job 3: integration tests ─────────────────────────────────────────────────
-  # Runs the webhook binary + mock Security Hub locally inside the runner.
-  # No AWS account, no external services — everything is self-contained.
   integration-test:
     name: Integration tests
+    needs: unit-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,11 +55,9 @@ jobs:
       - name: Run integration tests
         run: ./hack/integration-test.sh
 
-  # ── Job 4: E2E in Minikube ───────────────────────────────────────────────────
-  # Deploys the webhook and mock Security Hub into a real Kubernetes cluster,
-  # creates Trivy CRD objects, sends them to the webhook, and verifies findings.
   e2e-test:
     name: E2E tests (Minikube)
+    needs: [docker-build, integration-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
 
   integration-test:
     name: Integration tests
-    needs: unit-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +38,6 @@ jobs:
 
   e2e-test:
     name: E2E tests (Minikube)
-    needs: integration-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,24 +20,6 @@ jobs:
       - name: Run unit tests
         run: go test ./... -count=1 -v
 
-  docker-build:
-    name: Docker build
-    needs: unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Build image (amd64, no push)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          tags: trivy-webhook-aws-security-hub:ci
-
   integration-test:
     name: Integration tests
     needs: unit-test
@@ -57,7 +39,7 @@ jobs:
 
   e2e-test:
     name: E2E tests (Minikube)
-    needs: [docker-build, integration-test]
+    needs: integration-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,10 +1,10 @@
-name: Build, Update Chart, and Publish Docker image
+name: Publish main image
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -12,6 +12,64 @@ env:
 
 jobs:
   build:
+    name: Build (${{ matrix.platform_pair }})
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            platform_pair: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_pair: arm64
+            runner: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform_pair }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    name: Merge manifests and push main tag
+    needs: build
     runs-on: ubuntu-latest
 
     permissions:
@@ -21,41 +79,44 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - uses: docker/metadata-action@v5
         id: meta
-        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=main
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest digest
+        id: inspect
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true
+        continue-on-error: true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,10 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.platform_pair }})
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,91 @@
-name: Build, Update Chart, and Publish Docker image
+name: Release
 
 on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  test:
+    name: Unit + integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Unit tests
+        run: go test ./... -count=1 -v
+
+      - name: Integration tests
+        run: ./hack/integration-test.sh
+
   build:
+    name: Build (${{ matrix.platform_pair }})
+    needs: test
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            platform_pair: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_pair: arm64
+            runner: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform_pair }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    name: Merge manifests and push release tags
+    needs: build
     runs-on: ubuntu-latest
 
     permissions:
@@ -21,52 +95,59 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - uses: docker/metadata-action@v5
         id: meta
-        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          provenance: false
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest digest
+        id: inspect
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true
+        continue-on-error: true
 
-  release:
+  publish-chart:
+    name: Publish Helm chart
+    needs: merge
+    runs-on: ubuntu-latest
+
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -75,21 +156,23 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v4
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: custom packaging
+      - name: Package chart
         run: |
-          VERSION=${{github.ref_name}}
+          VERSION=${{ github.ref_name }}
           rm -rf .cr-release-packages
           mkdir -p .cr-release-packages
-          helm package charts/trivy-webhook-aws-security-hub --app-version=v${VERSION:1} --version=${VERSION:1} --destination=.cr-release-packages
+          helm package charts/trivy-webhook-aws-security-hub \
+            --app-version=v${VERSION:1} \
+            --version=${VERSION:1} \
+            --destination=.cr-release-packages
 
-      - name: Run chart-releaser
+      - name: Publish chart
         uses: askcloudarchitech/chart-releaser-action@skip-packaging-option
         with:
           skip_packaging: true
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -146,7 +146,6 @@ func ProcessTrivyWebhook(cfg Config) http.HandlerFunc {
 func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {
 	configAuditReport := &v1alpha1.ConfigAuditReport{}
 
-	// Decode JSON
 	err := json.Unmarshal(body, &configAuditReport)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding JSON: %v", err)
@@ -154,35 +153,40 @@ func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecuri
 
 	log.Printf("Processing report: %s", configAuditReport.Name)
 
-	// Prepare findings for AWS Security Hub BatchImportFindings API
-	var findings []types.AwsSecurityFinding
-
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("unable to load SDK config: %v", err)
 	}
 
-	// Create AWS STS clients
 	stsClient := sts.NewFromConfig(cfg)
 	callerIdentity, err := stsClient.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get caller identity: %w", err)
 	}
 
-	// Prepare variables
 	AWSAccountID := aws.ToString(callerIdentity.Account)
 	AWSRegion := cfg.Region
-	ProductArn := fmt.Sprintf("arn:aws:securityhub:%s::product/aquasecurity/aquasecurity", AWSRegion)
-	Name := fmt.Sprintf("%s/%s", configAuditReport.OwnerReferences[0].Kind, configAuditReport.OwnerReferences[0].Name)
 
-	// Handle Checks
+	return buildConfigAuditReportFindings(configAuditReport, AWSAccountID, AWSRegion, appCfg), nil
+}
+
+func buildConfigAuditReportFindings(configAuditReport *v1alpha1.ConfigAuditReport, AWSAccountID string, AWSRegion string, appCfg Config) []types.AwsSecurityFinding {
+	ProductArn := fmt.Sprintf("arn:aws:securityhub:%s::product/aquasecurity/aquasecurity", AWSRegion)
+
+	var Name string
+	if len(configAuditReport.OwnerReferences) > 0 {
+		Name = fmt.Sprintf("%s/%s", configAuditReport.OwnerReferences[0].Kind, configAuditReport.OwnerReferences[0].Name)
+	} else {
+		Name = configAuditReport.Name
+	}
+
+	var findings []types.AwsSecurityFinding
 	for _, check := range configAuditReport.Report.Checks {
 		severity := check.Severity
 		if severity == "UNKNOWN" {
 			severity = "INFORMATIONAL"
 		}
 
-		// Truncate description if too long
 		description := check.Description
 		if len(description) > 1024 {
 			description = description[:1021] + "..."
@@ -199,6 +203,11 @@ func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecuri
 		productFields := map[string]string{"Product Name": "Trivy"}
 		if appCfg.ClusterName != "" {
 			productFields["ClusterName"] = appCfg.ClusterName
+		}
+
+		message := ""
+		if len(check.Messages) > 0 {
+			message = check.Messages[0]
 		}
 
 		findings = append(findings, types.AwsSecurityFinding{
@@ -227,7 +236,7 @@ func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecuri
 					Region:    aws.String(AWSRegion),
 					Details: &types.ResourceDetails{
 						Other: map[string]string{
-							"Message": check.Messages[0],
+							"Message": message,
 						},
 					},
 				},
@@ -236,7 +245,7 @@ func getConfigAuditReportFindings(body []byte, appCfg Config) ([]types.AwsSecuri
 		})
 	}
 
-	return findings, nil
+	return findings
 }
 
 func getInfraAssessmentReport(body []byte, appCfg Config) ([]types.AwsSecurityFinding, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -176,6 +176,7 @@ func TestBuildConfigAuditReportFindingsNoOwnerReferences(t *testing.T) {
 
 	require.Len(t, findings, 1)
 	assert.Contains(t, aws.ToString(findings[0].Id), "cluster-level-report")
+	assert.Contains(t, aws.ToString(findings[0].Title), "cluster-level-report")
 	assert.Equal(t, "container foo is privileged", findings[0].Resources[0].Details.Other["Message"])
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -154,6 +154,57 @@ func TestBuildVulnerabilityReportFindingsClusterName(t *testing.T) {
 	assert.NotEqual(t, aws.ToString(withCluster[0].Id), aws.ToString(devCluster[0].Id))
 }
 
+func TestBuildConfigAuditReportFindingsNoOwnerReferences(t *testing.T) {
+	report := &v1alpha1.ConfigAuditReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cluster-level-report",
+			OwnerReferences: nil,
+		},
+		Report: v1alpha1.ConfigAuditReportData{
+			Checks: []v1alpha1.Check{
+				{
+					ID:       "KSV001",
+					Title:    "no privileged containers",
+					Severity: "HIGH",
+					Messages: []string{"container foo is privileged"},
+				},
+			},
+		},
+	}
+
+	findings := buildConfigAuditReportFindings(report, "123456789012", "eu-central-1", Config{})
+
+	require.Len(t, findings, 1)
+	assert.Contains(t, aws.ToString(findings[0].Id), "cluster-level-report")
+	assert.Equal(t, "container foo is privileged", findings[0].Resources[0].Details.Other["Message"])
+}
+
+func TestBuildConfigAuditReportFindingsEmptyMessages(t *testing.T) {
+	report := &v1alpha1.ConfigAuditReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "some-report",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "nginx"},
+			},
+		},
+		Report: v1alpha1.ConfigAuditReportData{
+			Checks: []v1alpha1.Check{
+				{
+					ID:       "KSV002",
+					Title:    "check with no messages",
+					Severity: "LOW",
+					Messages: nil,
+				},
+			},
+		},
+	}
+
+	findings := buildConfigAuditReportFindings(report, "123456789012", "eu-central-1", Config{})
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, "", findings[0].Resources[0].Details.Other["Message"])
+}
+
 func TestTruncateWithHash(t *testing.T) {
 	short := "short-value"
 	assert.Equal(t, short, truncateWithHash(short, 512))


### PR DESCRIPTION
## Summary

- **Bug:** `ConfigAuditReport` payloads with no `OwnerReferences` (e.g. `ClusterConfigAuditReport`) caused a `index out of range [0]` panic — falls back to `report.Name` now
- **Bug:** `check.Messages[0]` panicked when a check had no messages — uses empty string fallback now
- **Refactor:** extracted `buildConfigAuditReportFindings` as a pure testable function (mirrors `buildVulnerabilityReportFindings`), added 2 regression tests
- **CI:** jobs are now sequential — unit-test gates everything, e2e runs last; trigger removed from push-to-main (redundant after PR gate)
- **pre-release:** switches to `workflow_run` trigger so the `main` image only publishes after CI succeeds; native ARM64 runners (`ubuntu-24.04-arm`) replace QEMU
- **release:** sequential pipeline `test → build (amd64+arm64 native) → merge manifest → publish-chart`; no more double-build or parallel build/chart race

## Test plan

- [ ] Unit tests pass (`go test ./... -count=1`)
- [ ] `TestBuildConfigAuditReportFindingsNoOwnerReferences` covers the OwnerReferences panic
- [ ] `TestBuildConfigAuditReportFindingsEmptyMessages` covers the Messages panic
- [ ] CI workflow runs only on PRs, jobs are sequential in the Actions tab
- [ ] After merge, pre-release triggers via `workflow_run` (not immediately on push)
- [ ] Next release tag produces sequential test → amd64 build → arm64 build → manifest merge → chart publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of config-audit report handling when references or messages are missing.

* **Tests**
  * Added unit tests for config-audit report finding construction.

* **Chores**
  * Optimized CI/CD pipelines with improved job orchestration and multi-platform artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->